### PR TITLE
Endre tittel størrelser

### DIFF
--- a/README.template.md
+++ b/README.template.md
@@ -1,15 +1,14 @@
-Navn på appen/tjenesten/tingen
-================
+# Navn på appen/tjenesten/tingen
 
 Beskrivelse av hva appen/tjenesten/tingen som lages i dette repositoryet gjør.
 
-# Komme i gang
+## Komme i gang
 
 Hvordan bygge, teste og kjøre koden viss aktuelt.
 
 ---
 
-# Henvendelser
+## Henvendelser
 
 Enten:
 Spørsmål knyttet til koden eller repositoryet kan stilles som issues her på GitHub
@@ -17,6 +16,6 @@ Spørsmål knyttet til koden eller repositoryet kan stilles som issues her på G
 Eller:
 Spørsmål knyttet til koden eller repositoryet kan stilles til teamalias@nav.no (som evt må opprettes av noen™ Windows-mennesker) eller som issues her på GitHub (stryk det som ikke passer).
 
-## For Nav-ansatte
+### For Nav-ansatte
 
 Interne henvendelser kan sendes via Slack i kanalen #teamkanal.


### PR DESCRIPTION
Ved å bare ha en `<h1>` header og resten som undertitler av denne gjør det dokumentet semantisk enklere å tolke (spesielt hvis tolkning skjer automatisk).

Basert på [Markdown syntax for header-e funnet her](https://www.markdownguide.org/basic-syntax/#headings).